### PR TITLE
Some images don't build correctly with the rosidl_packages_interface

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -59,7 +59,7 @@
   <test_depend>ros2run</test_depend>
   <test_depend>sensor_msgs</test_depend>
 
-  <group_depend>rosidl_interface_packages</group_depend>
+  <group_depend condition="$ROSIDL_INTERFACE_PACKAGES == true">rosidl_interface_packages</group_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
group depend. Make this dependent on an env variable which needs to be set in order to pull that group in.