### PR TITLE
Add wireless_msgs to the build

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -36,6 +36,7 @@
   <build_depend>xmlrpcpp</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>nav_msgs</build_depend>
+  <build_depend>wireless_msgs</build_depend>
 
   <buildtool_export_depend>pkg-config</buildtool_export_depend>
 


### PR DESCRIPTION
This will be needed for the BLE nodes as they monitor the /connection topic which is ROS1.